### PR TITLE
Feature/ldsdk 2212 jaw predictor conversion

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -39,16 +39,16 @@ def convert(def_path, caffemodel_path, data_output_path, code_output_path, input
         if input_list_path or input_shape_list_path or output_list_path:
             mapper = TensorFlowMapper(transformer.graph)
             chains = mapper.map()
+            inputs = [x.name for x in transformer.graph.get_input_nodes()]
+            input_shapes = [[node.output_shape.width, node.output_shape.height, node.output_shape.channels] for node in transformer.graph.get_input_nodes()]
+            outputs = [x.name for x in transformer.graph.get_output_nodes()]            
             if input_list_path:
-                inputs = [[chain[0].node.parents[0].name for node in chain[0].node.parents] for chain in chains]
                 with open(input_list_path, 'wb') as input_list_out:
                     json.dump(inputs, input_list_out)
             if input_shape_list_path:
-                shapes = [[[node.output_shape.width, node.output_shape.height, node.output_shape.channels] for node in chain[0].node.parents] for chain in chains]
                 with open(input_shape_list_path, 'wb') as input_shape_list_out:
-                    json.dump(shapes, input_shape_list_out)
+                    json.dump(input_shapes, input_shape_list_out)
             if output_list_path:
-                outputs = [chain[-1].node.name for chain in chains]
                 with open(output_list_path, 'wb') as output_list_out:
                     json.dump(outputs, output_list_out)
         print_stderr('Done.')

--- a/kaffe/layers.py
+++ b/kaffe/layers.py
@@ -70,7 +70,6 @@ class NodeKind(LayerType):
             val = LAYER_DESCRIPTORS[node.kind](node)
             return val
         except NotImplementedError:
-            print('yo')
             raise KaffeError('Output shape computation not implemented for type: %s' % node.kind)
 
 
@@ -93,7 +92,6 @@ class NodeDispatch(object):
     def get_handler(self, node_kind, prefix):
         name = self.get_handler_name(node_kind)
         name = '_'.join((prefix, name))
-        print name
         try:
             return getattr(self, name)
         except AttributeError:

--- a/kaffe/layers.py
+++ b/kaffe/layers.py
@@ -22,7 +22,7 @@ LAYER_DESCRIPTORS = {
     'EuclideanLoss': shape_scalar,
     'Eltwise': shape_identity,
     'Exp': shape_identity,
-    'Flatten': shape_not_implemented,
+    'Flatten': flatten_shape,
     'HDF5Data': shape_data,
     'HDF5Output': shape_identity,
     'HingeLoss': shape_scalar,
@@ -49,6 +49,7 @@ LAYER_DESCRIPTORS = {
     'TanH': shape_identity,
     'WindowData': shape_not_implemented,
     'Threshold': shape_identity,
+    'Reshape':reshape_shape
 }
 
 LAYER_TYPES = LAYER_DESCRIPTORS.keys()
@@ -69,6 +70,7 @@ class NodeKind(LayerType):
             val = LAYER_DESCRIPTORS[node.kind](node)
             return val
         except NotImplementedError:
+            print('yo')
             raise KaffeError('Output shape computation not implemented for type: %s' % node.kind)
 
 
@@ -91,6 +93,7 @@ class NodeDispatch(object):
     def get_handler(self, node_kind, prefix):
         name = self.get_handler_name(node_kind)
         name = '_'.join((prefix, name))
+        print name
         try:
             return getattr(self, name)
         except AttributeError:

--- a/kaffe/shapes.py
+++ b/kaffe/shapes.py
@@ -25,6 +25,7 @@ def get_strided_kernel_output_shape(node, round_func):
 
 def shape_not_implemented(node):
     raise NotImplementedError
+    
 
 
 def shape_identity(node):
@@ -69,7 +70,35 @@ def shape_concat(node):
             output_shape[axis] += parent.output_shape[axis]
     return tuple(output_shape)
 
+def reshape_shape(node) :
+    
+    input_shape = node.get_only_parent().output_shape
+    input_shape_pr = input_shape.channels*input_shape.height*input_shape.width
+    input_shape_arr = [input_shape.batch_size,input_shape.channels,input_shape.height,input_shape.width]
+    pr = 1
+    axes = node.parameters.shape.dim
+    new_shape = [input_shape.batch_size,1,1,1]
+    for j in range(1,len(axes)) :
+        if axes[j] == 0 :
+            new_shape[j] = input_shape_arr[j]
+            pr *= new_shape[j]
+        elif not axes[j] == -1 :
+            new_shape[j] = int(axes[j])
+            pr *= new_shape[j]
+        elif axes[j] == -1 :
+            new_shape[j] = -1
 
+    for j in range(1,len(new_shape)) :
+        if new_shape[j] == -1 :
+            new_shape[j] = int(input_shape_pr/pr)
+
+    return TensorShape(new_shape[0],new_shape[1],new_shape[2],new_shape[3])                
+
+def flatten_shape(node) :
+    shape1 = node.get_only_parent().output_shape
+    
+    return TensorShape(shape1.batch_size,shape1.channels*shape1.height*shape1.width,1,1)
+    
 def shape_convolution(node):
     return get_strided_kernel_output_shape(node, math.floor)
 

--- a/kaffe/shapes.py
+++ b/kaffe/shapes.py
@@ -24,8 +24,7 @@ def get_strided_kernel_output_shape(node, round_func):
 
 
 def shape_not_implemented(node):
-    raise NotImplementedError
-    
+    raise NotImplementedError  
 
 
 def shape_identity(node):

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -257,5 +257,5 @@ class Network(object):
         input = tf.transpose(input,(0,3,1,2))
         dim = 1
         for d in input.get_shape()[1:].as_list():
-                dim *= d
+          dim *= d
         return tf.reshape(input,[-1,dim],name = name)

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -259,4 +259,3 @@ class Network(object):
         for d in input.get_shape()[1:].as_list():
                 dim *= d
         return tf.reshape(input,[-1,dim],name = name)
-            

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -177,7 +177,7 @@ class Network(object):
 
     @layer
     def concat(self, inputs, axis, name):
-        return tf.concat(concat_dim=axis, values=inputs, name=name)
+        return tf.concat(axis=axis, values=inputs, name=name)
 
     @layer
     def add(self, inputs, name):
@@ -238,7 +238,25 @@ class Network(object):
                 output = tf.nn.relu(output)
             return output
 
+            
     @layer
     def dropout(self, input, keep_prob, name):
         keep = 1 - self.use_dropout + (self.use_dropout * keep_prob)
         return tf.nn.dropout(input, keep, name=name)
+
+    @layer
+    def reshape(self,input,b,x,y,c,name,transpose = False) :
+        if transpose :
+            input = tf.reshape(input,[-1,c,x,y])
+            return tf.transpose(input,(0,2,3,1))
+
+        return tf.reshape(input,[-1,x,y,c],name = name)
+
+    @layer
+    def flatten(self,input,name):
+        input = tf.transpose(input,(0,3,1,2))
+        dim = 1
+        for d in input.get_shape()[1:].as_list():
+                dim *= d
+        return tf.reshape(input,[-1,dim],name = name)
+            

--- a/kaffe/tensorflow/transformer.py
+++ b/kaffe/tensorflow/transformer.py
@@ -139,14 +139,20 @@ class TensorFlowMapper(NodeMapper):
         return TensorFlowNode('lrn', int(params.local_size / 2), alpha, params.beta)
 
     def map_concat(self, node):
-        axis = (2, 3, 1, 0)[node.parameters.axis]
+        if node.parents[0].kind == 'Flatten':
+            axis = node.parameters.axis
+        else :    
+            axis = (2, 3, 1, 0)[node.parameters.axis]
         return TensorFlowNode('concat', axis)
 
     def map_dropout(self, node):
         return TensorFlowNode('dropout', node.parameters.dropout_ratio)
 
     def map_batch_norm(self, node):
-        scale_offset = len(node.data) == 4
+        if node.data :
+            scale_offset = len(node.data) == 4
+        else :
+            scale_offset = True    
         kwargs = {} if scale_offset else {'scale_offset': False}
         return MaybeActivated(node, default=False)('batch_normalization', **kwargs)
 
@@ -157,6 +163,25 @@ class TensorFlowMapper(NodeMapper):
             return TensorFlowNode(operations[op_code])
         except KeyError:
             raise KaffeError('Unknown elementwise operation: {}'.format(op_code))
+
+    def map_reshape(self,node) :
+
+        shape = node.output_shape
+        new_shape = [0]*4
+        new_shape[0] = shape[0]
+        new_shape[1] = shape[2]
+        new_shape[2] = shape[3]
+        new_shape[3] = shape[1]
+        parent_shape = node.get_only_parent().output_shape
+
+        ## we need to transpose again if a fc layer is reshaped to conv
+        kwargs = {'transpose' : False}
+        if parent_shape.height == 1 and parent_shape.width == 1 :
+            kwargs['transpose'] = True
+        return TensorFlowNode('reshape',new_shape[0],new_shape[1],new_shape[2],new_shape[3],**kwargs)
+
+    def map_flatten(self,node) :
+        return TensorFlowNode('flatten')
 
     def commit(self, chains):
         return chains

--- a/kaffe/tensorflow/transformer.py
+++ b/kaffe/tensorflow/transformer.py
@@ -139,7 +139,7 @@ class TensorFlowMapper(NodeMapper):
         return TensorFlowNode('lrn', int(params.local_size / 2), alpha, params.beta)
 
     def map_concat(self, node):
-        if node.parents[0].kind == 'Flatten':
+        if node.parents[0].output_shape[2] == 1 and node.parents[0].output_shape[3] == 1:
             axis = node.parameters.axis
         else :    
             axis = (2, 3, 1, 0)[node.parameters.axis]


### PR DESCRIPTION
### What

A PR to bring in support for Flatten and Reshape layers and multiple inputs.

### How
This combines an [external PR](https://github.com/ethereon/caffe-tensorflow/pull/147/files) bringing in support for the new layer types, with some of my changes to support mutliple input and intermediate layers with multiple inputs.  Concat has been extended to support vector inputs rather than just 4D image inputs because Flatten, Reshape and FC layers all produce vector outputs.